### PR TITLE
fixed deprecation messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra')
 const parseJson = require('json-parse-better-errors')
 const jsYaml = require('js-yaml')
 const glob = require('globby')
+const mime = require('mime-types')
 
 const mimeToParseFunc = {
 	'application/json': parseJson,
@@ -10,32 +11,35 @@ const mimeToParseFunc = {
 }
 
 class StaticMetaSource {
-	constructor (api, options) {
+	constructor(api, options) {
 		this.options = options
 		this.context = api.context
-		this.store = api.store
 
-		api.loadSource(async () => {
-			await this.parseFiles()
+		api.loadSource(async (actions) => {
+			await this.parseFiles(actions)
 		})
 	}
 
-	async parseFiles () {
-		const files = await glob(this.options.path, { cwd: this.context })
-		
+	async parseFiles(actions) {
+		const files = await glob(this.options.path, {
+			cwd: this.context
+		})
+
 		await Promise.all(files.map(async file => {
-			const mimeType = this.store.mime.lookup(file)
-			
+			const mimeType = mime.lookup(file)
+
 			if (!mimeToParseFunc[mimeType]) return
 			const absPath = path.join(this.context, file)
 			const content = await fs.readFile(absPath, 'utf8')
 			const data = mimeToParseFunc[mimeType](content)
 
-			const fields = typeof data !== 'object' || Array.isArray(data)
-				? { '_untypedSettings': data }
-			: data
+			const fields = typeof data !== 'object' || Array.isArray(data) ?
+				{
+					'_untypedSettings': data
+				} :
+				data
 			for (const key of Object.keys(fields)) {
-				this.store.addMetaData(key, fields[key])
+				actions.addMetadata(key, fields[key])
 			}
 		}))
 	}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",
-    "json-parse-better-errors": "^1.0.2"
+    "json-parse-better-errors": "^1.0.2",
+    "mime-types": "^2.1.25"
   },
   "devDependencies": {
     "eslint": "^6.2.0"


### PR DESCRIPTION
fixes the following deprecation messages:

* Avoid using api.store directly. Use the actions in api.loadSource() instead.
* The store.addMetaData() method has been renamed to store.addMetadata(). 